### PR TITLE
Stamp Package.swift for 7.0.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "ScateSDK",
-            url: "https://github.com/scate-io/ScateSDK-ios/releases/download/v7.0.14/ScateSDK.xcframework-v7.0.14.zip",
-            checksum: "fcfb22bdc8a1bb023e920718e3dc65fd0e837e45a3c9e6f597a4e9e619ab5341"
+            url: "https://github.com/scate-io/ScateSDK-ios/releases/download/v7.0.15/ScateSDK.xcframework-v7.0.15.zip",
+            checksum: "1191ce7b3a3696da53b60e2897cdf8e4758e9f11e701ff09f77a040fb129d38f"
         ),
         .target(
             name: "ScateSDKAdjust",

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ In Xcode, go to **File → Add Package Dependencies…** and enter the package U
 https://github.com/scate-io/ScateSDK-ios
 ```
 
-Set the **Dependency Rule** to **Up to Next Major Version** from `7.0.14`, then add the **ScateSDK** library product to your app target.
+Set the **Dependency Rule** to **Up to Next Major Version** from `7.0.15`, then add the **ScateSDK** library product to your app target.
 
 Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/scate-io/ScateSDK-ios", from: "7.0.14")
+    .package(url: "https://github.com/scate-io/ScateSDK-ios", from: "7.0.15")
 ]
 ```
 


### PR DESCRIPTION
The v7.0.15 release (xcframework zip, podspec, CocoaPods) went out through the ScateCoreSDK-ios Action, but the Action does not touch `Package.swift`, so Swift Package Manager still points at the 7.0.14 zip. This stamps the 7.0.15 zip URL and its checksum (`swift package compute-checksum` on the release asset) and moves the README's SPM version.

Note for whoever merges: SPM reads `Package.swift` from the tagged tree, and the `v7.0.15` tag already points at the "Update podspec for 7.0.15" commit. After merging, the tag has to be moved onto the merge commit (`git tag -f v7.0.15 && git push -f origin v7.0.15`) or SPM users asking for 7.0.15 keep getting the 7.0.14 binary. CocoaPods is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)